### PR TITLE
Close #1: Wrap List

### DIFF
--- a/src/list.hpp
+++ b/src/list.hpp
@@ -393,13 +393,13 @@ private:
      * The constructor only copies pointer to `list`
      * and wraps it.
      */
-    List(const shared_ptr<const List_>& list) : list{list} {
+    explicit List(const shared_ptr<const List_>& list) : list{list} {
     };
 public:
     /** \brief Create list with a single element.
      * \param value Value of the head.
      */
-    List(const T& value)
+    explicit List(const T& value)
         : list{new List_{value}, List_::destroy} {
     }
     /**
@@ -440,7 +440,7 @@ public:
      * @copydoc List_::insert
      */
     const List insert(const T& value, const size_t position = 0) const {
-        return this->list->insert(value, position);
+        return List{this->list->insert(value, position)};
     }
     /**
      * @copydoc List_::remove
@@ -504,7 +504,7 @@ public:
      * See List_::fill for implementation details.
      */
     static const List fill(size_t amount, const T& value) {
-        return List_::fill(amount, value);
+        return List{List_::fill(amount, value)};
     }
 };
 

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -396,20 +396,21 @@ private:
     explicit List(const shared_ptr<const List_>& list) : list{list} {
     };
 public:
-    /** \brief Create list with a single element.
+    /** \brief Create a list with a single element.
      * \param value Value of the head.
      */
     explicit List(const T& value)
         : list{new List_{value}, List_::destroy} {
     }
     /**
+     * \brief Create a list with head and tail.
      * \param value Value of the head.
      * \param tail Tail of the list.
      */
     List(const T& value, const List<T>& tail)
         : list{new List_{value, tail.list}, List_::destroy} {
     }
-    /** \brief Creates new instance of List from initializer list.
+    /** \brief Create new instance of List from initializer list.
      * \param value Initializer list of values for the list.
      */
     explicit List(const initializer_list<T> value)

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -49,7 +49,8 @@ private:
          */
         ListPtr reverse_(ListPtr acc=nullptr) const {
             return this->tail_
-                ? this->tail_->reverse_(ListPtr{new List_{this->value, acc}, List_::destroy})
+                ? this->tail_->reverse_(
+                    ListPtr{new List_{this->value, acc}, List_::destroy})
                 : ListPtr{new List_{this->value, acc}, List_::destroy};
         }
         /**

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -38,25 +38,25 @@ private:
          * \param amount Number of nodes to be removed.
          * \return List without `amount` first elements.
          */
-        ListPtr _drop(const size_t amount) const {
+        ListPtr drop_(const size_t amount) const {
             return amount
-                ? this->tail_->_drop(amount - 1)
+                ? this->tail_->drop_(amount - 1)
                 : this->tail_;
         }
         /**
          * \param acc List that will be appended to end of resulting list.
          * \return Reversed list with `acc` appended.
          */
-        ListPtr _reverse(ListPtr acc=nullptr) const {
+        ListPtr reverse_(ListPtr acc=nullptr) const {
             return this->tail_
-                ? this->tail_->_reverse(ListPtr{new List_{this->value, acc}, List_::destroy})
+                ? this->tail_->reverse_(ListPtr{new List_{this->value, acc}, List_::destroy})
                 : ListPtr{new List_{this->value, acc}, List_::destroy};
         }
         /**
          * \param value Value to be inserted.
          * \param position Index of the inserted element in resulting list.
          */
-        ListPtr _insert(const T& value, const size_t position) const {
+        ListPtr insert_(const T& value, const size_t position) const {
             if (position == 0) {
                 return this->insertFirst(value);
             } else if (position == this->size_) {
@@ -84,7 +84,7 @@ private:
             return this
                 ->reverse()
                 ->drop(this->size_ - position - 1)
-                ->_reverse(ListPtr{new List_{value, this->drop(position - 1)}, List_::destroy});
+                ->reverse_(ListPtr{new List_{value, this->drop(position - 1)}, List_::destroy});
         }
         /** \brief Helper function for fill().
          * \param amount Size of list to be created.
@@ -214,7 +214,7 @@ private:
                     "Position should not be greater than list size"
                 );
             }
-            return this->_insert(value, position);
+            return this->insert_(value, position);
         }
         /**
          * \param position Position of element to be removed.
@@ -245,7 +245,7 @@ private:
          * \return List with elements in reversed order.
          */
         ListPtr reverse() const {
-            return this->_reverse();
+            return this->reverse_();
         }
         /**
          * \param first Amount of elements to be dropped
@@ -287,7 +287,7 @@ private:
         ListPtr drop(const size_t amount) const {
             return (amount >= this->size_)
                 ? nullptr
-                : this->_drop(amount);
+                : this->drop_(amount);
         }
         /**
          * \param value Value to append.
@@ -303,7 +303,7 @@ private:
          * \return Concatenation of current list with `list`.
          */
         ListPtr concat(ListPtr list) const {
-            return this->reverse()->_reverse(list);
+            return this->reverse()->reverse_(list);
         }
         /**
          * \brief Check whether lists are not equal.

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -71,7 +71,8 @@ private:
          * \return List with `value` in head and `this` in tail.
          */
         ListPtr insertFirst(const T& value) const {
-            return ListPtr{new List_{value, this->shared_from_this()}, List_::destroy};
+            return ListPtr{
+                new List_{value, this->shared_from_this()}, List_::destroy};
         }
         /**
          * \param value Value to be inserted.
@@ -85,7 +86,8 @@ private:
             return this
                 ->reverse()
                 ->drop(this->size_ - position - 1)
-                ->reverse_(ListPtr{new List_{value, this->drop(position - 1)}, List_::destroy});
+                ->reverse_(ListPtr{new List_{value, this->drop(position - 1)},
+                                   List_::destroy});
         }
         /** \brief Helper function for fill().
          * \param amount Size of list to be created.
@@ -129,7 +131,8 @@ private:
          */
         List_(const T* begin, const size_t size)
                 : value{*begin}
-                , tail_{size > 1? ListPtr{new List_(begin + 1, size - 1), List_::destroy}
+                , tail_{size > 1? ListPtr{new List_(begin + 1, size - 1),
+                                          List_::destroy}
                                : nullptr}
                 , size_{size} {
         }
@@ -169,7 +172,8 @@ private:
         explicit List_(const initializer_list<T> value)
                 : value{*value.begin()}
                 , tail_{value.size() > 1
-                    ? ListPtr{new List_{value.begin() + 1, value.size() - 1}, List_::destroy}
+                    ? ListPtr{new List_{value.begin() + 1, value.size() - 1},
+                              List_::destroy}
                     : nullptr}
                 , size_{value.size()} {
             if (value.size() == 0) {

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -10,19 +10,18 @@ using std::initializer_list;
 /**
  * \brief Immutable list implementation.
  */
-template<typename T> class List
-        : public std::enable_shared_from_this< List<T> >
-        {
+template<typename T> class List {
+private:
     /**
-     * Handy alias for List template with T parameter.
-     * Allows to avoid ugly code like `shared_ptr<List<T>>`.
+     * \brief Internal implementation of immutable list
+     * which needs to be wrapped into public List.
      */
-    using List_ = List<T>;
-    /**
-     * Handy alias for List pointer wrapped into shared pointer.
-     */
-    using ListPtr = const shared_ptr<const List_>;
+    class List_ : public std::enable_shared_from_this<List_> {
     private:
+        /**
+         * Handy alias for List pointer wrapped into shared pointer.
+         */
+        using ListPtr = const shared_ptr<const List_>;
         /**
          * value that the list stores.
          */
@@ -50,8 +49,8 @@ template<typename T> class List
          */
         ListPtr _reverse(ListPtr acc=nullptr) const {
             return this->tail_
-                ? this->tail_->_reverse(List_::Cons(this->value, acc))
-                : List_::Cons(this->value, acc);
+                ? this->tail_->_reverse(ListPtr{new List_{this->value, acc}, List_::destroy})
+                : ListPtr{new List_{this->value, acc}, List_::destroy};
         }
         /**
          * \param value Value to be inserted.
@@ -71,7 +70,7 @@ template<typename T> class List
          * \return List with `value` in head and `this` in tail.
          */
         ListPtr insertFirst(const T& value) const {
-            return List_::Cons(value, this->shared_from_this());
+            return ListPtr{new List_{value, this->shared_from_this()}, List_::destroy};
         }
         /**
          * \param value Value to be inserted.
@@ -85,7 +84,7 @@ template<typename T> class List
             return this
                 ->reverse()
                 ->drop(this->size_ - position - 1)
-                ->_reverse(List_::Cons(value, this->drop(position - 1)));
+                ->_reverse(ListPtr{new List_{value, this->drop(position - 1)}, List_::destroy});
         }
         /** \brief Helper function for fill().
          * \param amount Size of list to be created.
@@ -93,7 +92,7 @@ template<typename T> class List
          * that should be appended as a tail to newly created list.
          * \param value Value that should appear in each node of new list.
          *
-         * I need the `tail` to be an instance of `shared_ptr<List<T>>`.
+         * I need the `tail` to be an instance of ListPtr.
          * Separate List(const T&, const List_*) constructor
          * was created for this purpose.
          *
@@ -103,10 +102,10 @@ template<typename T> class List
          * in the case of fill_() fail
          * to avoid memory leak.
          */
-        static const List_* fill_(unsigned amount, const List*& tail,
+        static const List_* fill_(unsigned amount, const List_*& tail,
                                   const T& value) {
             if (!amount) {
-                const List* result = tail;
+                const List_* result = tail;
                 tail = nullptr;
                 return result;
             }
@@ -118,16 +117,18 @@ template<typename T> class List
          * \param size Size of the `begin` array.
          *
          * Used in List(const initializer_list<T>) constructor.
-         * First element of `begin` array becomes a value of head of the list.
+         * First element of `begin` array
+         * becomes a value of head of the list.
          * If there are more than one element in the array,
-         * tail will be created recursively from pointer to the second element.
+         * tail will be created recursively
+         * from pointer to the second element.
          *
          * Should not be used with empty arrays.
          * Size should be specified correctly.
          */
-        List(const T* begin, const size_t size)
+        List_(const T* begin, const size_t size)
                 : value{*begin}
-                , tail_{size > 1? new List_(begin + 1, size - 1)
+                , tail_{size > 1? ListPtr{new List_(begin + 1, size - 1), List_::destroy}
                                : nullptr}
                 , size_{size} {
         }
@@ -139,17 +140,24 @@ template<typename T> class List
          * Wraps `tail_` into `shared_ptr`
          * and adds custom destruction strategy destroy().
          */
-        List(const T& value, const List_* tail_)
+        List_(const T& value, const List_* tail_)
             : value{value}
-            , tail_{tail_, List::destroy}
+            , tail_{tail_, List_::destroy}
             , size_{tail_ ? tail_->size_ + 1 : 1} {
         }
+        /**
+         * Custom destruction function List_::destroy()
+         * should be used instead of destructor for long lists
+         * in order to avoid stack overflow
+         * during recursive calls.
+         */
+        ~List_() = default;
     public:
         /**
          * \param value Value of the head.
          * \param tail_ Tail of the list.
          */
-        List(const T& value, ListPtr& tail_=nullptr)
+        List_(const T& value, ListPtr& tail_)
                 : value{value}
                 , tail_{tail_}
                 , size_{tail_? tail_->size_ + 1 : 1} {
@@ -157,10 +165,10 @@ template<typename T> class List
         /** \brief Creates new instance of List from initializer list.
          * \param value Initializer list of values for the list.
          */
-        explicit List(const initializer_list<T> value)
+        explicit List_(const initializer_list<T> value)
                 : value{*value.begin()}
                 , tail_{value.size() > 1
-                    ? new List_{value.begin() + 1, value.size() - 1}
+                    ? ListPtr{new List_{value.begin() + 1, value.size() - 1}, List_::destroy}
                     : nullptr}
                 , size_{value.size()} {
             if (value.size() == 0) {
@@ -175,7 +183,16 @@ template<typename T> class List
          * This means that instead of copying
          * you can freely use existent instance of the List.
          */
-        List(const List_&) = delete;
+        List_(const List_&) = delete;
+        /**
+         * We cannot copy, but sometimes we need an ability to move list.
+         * For example, when some function returns a List_
+         * and we store it in variable,
+         * it needs to be either copied or moved.
+         * We have prevented copying by deleting List_(const List_&),
+         * so the copy constructor was explicitly introduced.
+         */
+        List_(List_&&) = default;
         /**
          * Get size of the list in OOP way.
          */
@@ -252,7 +269,9 @@ template<typename T> class List
             }
 
             if (first == 0) {
-                return this->reverse()->drop(this->size_ - last - 2)->reverse();
+                return this->reverse()
+                           ->drop(this->size_ - last - 2)
+                           ->reverse();
             } else if (last >= this->size_ - 1) {
                 return this->drop(first - 1);
             } else {
@@ -276,9 +295,10 @@ template<typename T> class List
          * appended to current list.
          */
         ListPtr append(const T& value) const {
-            return this->concat(List_::Cons(value));
+            return this->concat(ListPtr{new List_{value}, List_::destroy});
         }
         /**
+         * \brief Unite two lists together.
          * \param list List to be concatenated.
          * \return Concatenation of current list with `list`.
          */
@@ -296,7 +316,8 @@ template<typename T> class List
             return false
                 || ((!this->tail_) ^ (!list.tail_))
                 || (this->value != list.value)
-                || (this->tail_ != list.tail_ && *(this->tail_) != *(list.tail_));
+                || (this->tail_ != list.tail_
+                    && *(this->tail_) != *(list.tail_));
         }
         /**
          * \brief Check whether lists are equal.
@@ -309,26 +330,16 @@ template<typename T> class List
             return !(*this != list);
         }
         /**
-         * \brief Creates `shared_ptr` to List
-         * with custom destruction strategy destroy().
-         * \param head Head for new list.
-         * \param tail Tail for new list.
-         * \return List with specified `head` and `tail`.
-         */
-        static ListPtr Cons(const T& head, ListPtr& tail = nullptr) {
-            return ListPtr{new List_(head, tail), List_::destroy};
-        }
-        /**
          * \param amount Size of list to be created.
          * \param value Value that should appear in each node of new list.
          *
-         * Public iterface for private fill_() method.
-         * It wraps insertBulk_() result into `shared_ptr`
+         * Public iterface for private List_::fill_() method.
+         * It wraps List_::fill_() result into `shared_ptr`
          * with custom destruction function destroy().
          *
          * Also it creates a guard for tail,
          * that will destroy the tail if something will go wrong.
-         * fill_() should store `tail`,
+         * List::fill_() should store `tail`,
          * that is not yet wrapped into `shared_ptr`,
          * in the guard, and set it to `nullptr` in the end
          * in order to avoid destruction of successfully created list.
@@ -339,14 +350,14 @@ template<typename T> class List
             }
 
             struct TailGuard {
-                const List* ptr;
+                const List_* ptr;
                 ~TailGuard() {
-                    List::destroy(this->ptr);
+                    List_::destroy(this->ptr);
                 }
             } guard{};
-            const List* result = fill_(amount, guard.ptr, value);
+            const List_* result = fill_(amount, guard.ptr, value);
             return amount
-                ? ListPtr{result, List::destroy}
+                ? ListPtr{result, List_::destroy}
                 : nullptr;
         }
         /** \brief Custom destruction strategy,
@@ -370,15 +381,131 @@ template<typename T> class List
 
             for (; tail && tail.use_count() == 1; tail = tail->tail_);
         }
-        /**
-         * Destructor cannot be hidden yet,
-         * but it should be,
-         * because custom destruction function destroy()
-         * should be used instead for long lists
-         * in order to avoid stack overflow
-         * during recursive calls.
-         */
-        ~List() {}
+    };
+    /** \brief Pointer to wrapped list.
+     */
+    const shared_ptr<const List_> list;
+    /** \brief Construct list wrapper.
+     * \param list List_ to be wrapped.
+     *
+     * This constructor uses private class List_,
+     * so it's not for a public usage.
+     * The constructor only copies pointer to `list`
+     * and wraps it.
+     */
+    List(const shared_ptr<const List_>& list) : list{list} {
+    };
+public:
+    /** \brief Create list with a single element.
+     * \param value Value of the head.
+     */
+    List(const T& value)
+        : list{new List_{value}, List_::destroy} {
+    }
+    /**
+     * \param value Value of the head.
+     * \param tail Tail of the list.
+     */
+    List(const T& value, const List<T>& tail)
+        : list{new List_{value, tail.list}, List_::destroy} {
+    }
+    /** \brief Creates new instance of List from initializer list.
+     * \param value Initializer list of values for the list.
+     */
+    explicit List(const initializer_list<T> value)
+        : list{new List_{value}, List_::destroy} {
+    }
+    /**
+     * List instances can be copied,
+     * because it's a wrapper
+     * and will not copy all elements.
+     */
+    List(const List&) = default;
+    /**
+     * When we should store returned value from some function in variable,
+     * it's better to have an ability to move it than copy and destroy.
+     */
+    List(List&& list) = default;
+    /**
+     * \brief Destructor is default.
+     */
+    ~List() = default;
+    /**
+     * @copydoc List_::size
+     */
+    size_t size() const {
+        return this->list->size();
+    }
+    /**
+     * @copydoc List_::insert
+     */
+    const List insert(const T& value, const size_t position = 0) const {
+        return this->list->insert(value, position);
+    }
+    /**
+     * @copydoc List_::remove
+     */
+    const List remove(const size_t position = 0) const {
+        return List{this->list->remove(position)};
+    }
+    /**
+     * @copydoc List_::tail
+     */
+    const List tail() const {
+        return List{this->list->tail()};
+    }
+    /**
+     * @copydoc List_::reverse
+     */
+    const List reverse() const {
+        return List{this->list->reverse()};
+    }
+    /**
+     * @copydoc List_::slice
+     */
+    const List slice(const size_t first, const size_t last = -1) const {
+        return List{this->list->slice(first, last)};
+    }
+    /**
+     * @copydoc List_::drop
+     */
+    const List drop(const size_t amount) const {
+        return List{this->list->drop(amount)};
+    }
+    /**
+     * @copydoc List_::append
+     */
+    const List append(const T& value) const {
+        return List{this->list->append(value)};
+    }
+    /**
+     * @copydoc List_::concat
+     */
+    const List concat(const List& list) const {
+        return List{this->list->concat(list.list)};
+    }
+    /**
+     * @copydoc List_::operator!=
+     */
+    bool operator!=(const List& list) const {
+        return *this->list != *list.list;
+    }
+    /**
+     * @copydoc List_::operator==
+     */
+    bool operator==(const List& list) const {
+        return *this->list == *list.list;
+    }
+    /**
+     * \brief Create new List of specific length with specific values.
+     * \param amount Size of list to be created.
+     * \param value Value that should appear in each node of new list.
+     *
+     * See List_::fill for implementation details.
+     */
+    static const List fill(size_t amount, const T& value) {
+        return List_::fill(amount, value);
+    }
 };
 
 #endif

--- a/tests/unit/testlist.cpp
+++ b/tests/unit/testlist.cpp
@@ -20,12 +20,11 @@ TYPED_TEST(ListTest, ParametrisedConstructorCreatesNotEqual) {
 
 TYPED_TEST(ListTest, ChainsWithEqualParametersAreEqual) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list_aa = ListPtr_(new List_(1));
+    List_ list_aa(1);
     List_ list_ab(2, list_aa);
 
-    ListPtr_ list_ba = ListPtr_(new List_(1));
+    List_ list_ba(1);
     List_ list_bb(2, list_ba);
 
     ASSERT_TRUE(list_ab == list_bb);
@@ -33,9 +32,8 @@ TYPED_TEST(ListTest, ChainsWithEqualParametersAreEqual) {
 
 TYPED_TEST(ListTest, ConstructsListCorrectlyFromInitializerList) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list_aa = ListPtr_(new List_(2));
+    List_ list_aa(2);
     List_ list_ab(1, list_aa);
     List_ list_bb({1, 2});
 
@@ -44,93 +42,87 @@ TYPED_TEST(ListTest, ConstructsListCorrectlyFromInitializerList) {
 
 TYPED_TEST(ListTest, ChainsWithNotEqualParametersAreNotEqual) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list_aa = ListPtr_(new List_(1));
+    List_ list_aa(1);
     List_ list_ab(2, list_aa);
 
-    ListPtr_ list_ba = ListPtr_(new List_(2));
+    List_ list_ba(2);
     List_ list_bb(2, list_ba);
 
     List_ list_cc{1, 2};
 
     ASSERT_TRUE(list_ab != list_bb);
-    ASSERT_TRUE(list_ab != *list_aa);
+    ASSERT_TRUE(list_ab != list_aa);
     ASSERT_TRUE(list_cc != list_bb);
     ASSERT_TRUE(list_cc != list_ab);
 }
 
 TYPED_TEST(ListTest, InsertsFirstNodeProperlyPtr) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list = ListPtr_(new List_(1));
-    ListPtr_ listConstructed = ListPtr_(new List_(2, list));
-    ListPtr_ listInserted = list->insert(2);
+    List_ list(1);
+    List_ listConstructed(2, list);
+    List_ listInserted = list.insert(2);
 
     List_ listProper{2, 1};
 
-    ASSERT_TRUE(*listInserted == *listConstructed);
-    ASSERT_TRUE(*listInserted == listProper);
+    ASSERT_TRUE(listInserted == listConstructed);
+    ASSERT_TRUE(listInserted == listProper);
 }
 
 TYPED_TEST(ListTest, InsertsFirstNodeProperly) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list = ListPtr_(new List_(1));
+    List_ list(1);
     List_ listConstructed(2, list);
 
     List_ listProper{2, 1};
 
-    ASSERT_TRUE(*list->insert(2) == listConstructed);
-    ASSERT_TRUE(*list->insert(2) == listProper);
-    ASSERT_TRUE(*list->insert(2) == *list->insert(2));
+    ASSERT_TRUE(list.insert(2) == listConstructed);
+    ASSERT_TRUE(list.insert(2) == listProper);
+    ASSERT_TRUE(list.insert(2) == list.insert(2));
 }
 
 TYPED_TEST(ListTest, InsertsLastNodeProperlyPtr) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list = ListPtr_(new List_(2));
-    ListPtr_ listConstructed = ListPtr_(new List_(1, list));
+    List_ list(2);
+    List_ listConstructed(1, list);
 
-    ListPtr_ listBeforeInsert = ListPtr_(new List_(1));
-    ListPtr_ listInserted = listBeforeInsert->insert(2, 1);
+    List_ listBeforeInsert(1);
+    List_ listInserted = listBeforeInsert.insert(2, 1);
 
     List_ listProper{1, 2};
 
-    ASSERT_TRUE(*listInserted == *listConstructed);
-    ASSERT_TRUE(*listInserted == listProper);
+    ASSERT_TRUE(listInserted == listConstructed);
+    ASSERT_TRUE(listInserted == listProper);
 }
 
 TYPED_TEST(ListTest, InsertsLastNodeProperly) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list_ = ListPtr_(new List_(2));
+    List_ list_(2);
     List_ listConstructed(1, list_);
 
-    ListPtr_ list = ListPtr_(new List_(1));
+    List_ list(1);
 
     List_ listProper{1, 2};
 
-    ASSERT_TRUE(*list->insert(2, 1) == listConstructed);
-    ASSERT_TRUE(*list->insert(2, 1) == listProper);
-    ASSERT_TRUE(*list->insert(2, 1) == *list->insert(2, 1));
+    ASSERT_TRUE(list.insert(2, 1) == listConstructed);
+    ASSERT_TRUE(list.insert(2, 1) == listProper);
+    ASSERT_TRUE(list.insert(2, 1) == list.insert(2, 1));
 }
 
 TYPED_TEST(ListTest, PopulatesListToThreeElementsProperly) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list = ListPtr_(new List_(1));
+    List_ list(1);
 
     List_ listProper{1, 2, 3};
 
-    ASSERT_TRUE(*list->insert(3, 1)->insert(2, 1) == listProper);
-    ASSERT_TRUE(*list->insert(3, 1)->insert(2, 1) ==
-                *list->insert(2, 1)->insert(3, 2));
+    ASSERT_TRUE(list.insert(3, 1).insert(2, 1) == listProper);
+    ASSERT_TRUE(list.insert(3, 1).insert(2, 1) ==
+                list.insert(2, 1).insert(3, 2));
 }
 
 TYPED_TEST(ListTest, TailShouldReturnAllExceptFirstElement) {
@@ -138,8 +130,8 @@ TYPED_TEST(ListTest, TailShouldReturnAllExceptFirstElement) {
 
     List_ list{1, 2, 3, 4, 5};
     List_ listTail{2, 3, 4, 5};
-    ASSERT_TRUE(*list.tail() == listTail);
-    ASSERT_FALSE(*list.tail() == list);
+    ASSERT_TRUE(list.tail() == listTail);
+    ASSERT_FALSE(list.tail() == list);
 }
 
 TYPED_TEST(ListTest, RemoveShouldRemoveFirstElementByDefault) {
@@ -147,8 +139,8 @@ TYPED_TEST(ListTest, RemoveShouldRemoveFirstElementByDefault) {
 
     List_ list{1, 2, 3, 4, 5};
     List_ listTail{2, 3, 4, 5};
-    ASSERT_TRUE(*list.tail() == *list.remove());
-    ASSERT_TRUE(*list.remove() == *list.remove(0));
+    ASSERT_TRUE(list.tail() == list.remove());
+    ASSERT_TRUE(list.remove() == list.remove(0));
 }
 
 TYPED_TEST(ListTest, RemoveShouldRemoveMiddleElementProperly) {
@@ -156,7 +148,7 @@ TYPED_TEST(ListTest, RemoveShouldRemoveMiddleElementProperly) {
 
     List_ list{1, 2, 3, 4, 5};
     List_ listAfter{1, 2, 4, 5};
-    ASSERT_TRUE(*list.remove(2) == listAfter);
+    ASSERT_TRUE(list.remove(2) == listAfter);
 }
 
 TYPED_TEST(ListTest, RemoveShouldRemoveLastElementProperly) {
@@ -164,14 +156,14 @@ TYPED_TEST(ListTest, RemoveShouldRemoveLastElementProperly) {
 
     List_ list{1, 2, 3, 4, 5};
     List_ listAfter{1, 2, 3, 4};
-    ASSERT_TRUE(*list.remove(4) == listAfter);
+    ASSERT_TRUE(list.remove(4) == listAfter);
 }
 
 TYPED_TEST(ListTest, ReverseShouldWorkForSingleElement) {
     using List_ = typename TestFixture::List_;
 
     List_ list{1};
-    ASSERT_TRUE(*list.reverse() == list);
+    ASSERT_TRUE(list.reverse() == list);
 }
 
 TYPED_TEST(ListTest, ReverseShouldWorkForTwoElementsList) {
@@ -179,7 +171,7 @@ TYPED_TEST(ListTest, ReverseShouldWorkForTwoElementsList) {
 
     List_ list{1, 2};
     List_ listReversed{2, 1};
-    ASSERT_TRUE(*list.reverse() == listReversed);
+    ASSERT_TRUE(list.reverse() == listReversed);
 }
 
 TYPED_TEST(ListTest, ReverseShouldWorkForMultipleElementsList) {
@@ -187,47 +179,44 @@ TYPED_TEST(ListTest, ReverseShouldWorkForMultipleElementsList) {
 
     List_ list{1, 2, 3, 4, 5};
     List_ listReversed{5, 4, 3, 2, 1};
-    ASSERT_TRUE(*list.reverse() == listReversed);
+    ASSERT_TRUE(list.reverse() == listReversed);
 }
 
 TYPED_TEST(ListTest, SliceShouldRemoveFirstElementsCorrectly) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list = ListPtr_(new List_{1, 2, 3, 4, 5});
-    ListPtr_ listSliced = ListPtr_(new List_{3, 4, 5});
+    List_ list{1, 2, 3, 4, 5};
+    List_ listSliced{3, 4, 5};
 
-    ASSERT_TRUE(*list->slice(2) == *listSliced);
+    ASSERT_TRUE(list.slice(2) == listSliced);
 }
 
 TYPED_TEST(ListTest, SliceShouldRemoveLastElementsCorrectly) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list = ListPtr_(new List_{1, 2, 3, 4, 5});
-    ListPtr_ listSliced = ListPtr_(new List_{1, 2, 3});
+    List_ list{1, 2, 3, 4, 5};
+    List_ listSliced{1, 2, 3};
 
-    ASSERT_TRUE(*list->slice(0, 2) == *listSliced);
+    ASSERT_TRUE(list.slice(0, 2) == listSliced);
 }
 
 TYPED_TEST(ListTest, SliceShouldRemoveBorderElementsCorrectly) {
     using List_ = typename TestFixture::List_;
-    using ListPtr_ = std::shared_ptr<const List_>;
 
-    ListPtr_ list = ListPtr_(new List_{1, 2, 3, 4, 5});
-    ListPtr_ listSliced = ListPtr_(new List_{2, 3});
+    List_ list{1, 2, 3, 4, 5};
+    List_ listSliced{2, 3};
 
-    ASSERT_TRUE(*list->slice(1, 2) == *listSliced);
+    ASSERT_TRUE(list.slice(1, 2) == listSliced);
 }
 
 TYPED_TEST(ListTest, FillSizeCorrect) {
     using List_ = typename TestFixture::List_;
 
-    ASSERT_TRUE(List_::fill(10, 0)->size() == 10);
+    ASSERT_TRUE(List_::fill(10, 0).size() == 10);
 }
 
 TYPED_TEST(ListTest, FillLargeSuccess) {
     using List_ = typename TestFixture::List_;
 
-    ASSERT_TRUE(List_::fill(1E5, 0)->size() == 1E5);
+    ASSERT_TRUE(List_::fill(1E5, 0).size() == 1E5);
 }

--- a/tests/unit/testlist.hpp
+++ b/tests/unit/testlist.hpp
@@ -3,7 +3,7 @@
 
 template<typename T> class ListTest : public ::testing::Test {
     public:
-        typedef List<T> List_;
+        using List_ = const List<const T>;
         static T shared_;
         T value_;
     protected:


### PR DESCRIPTION
- Rename `List` class to `List_`
- Make wrapper for the `List_` class

New conception allows to create and destroy long lists without stack overflow error and making destructor for shared pointer by hand. Original `List` class is placed into wrapper and public functions are exposed to the wrapper.

Shared pointer used for wrapped list to have proper memory management. That's why it's not needed to use shared pointer explicitly to place list into heap.